### PR TITLE
Install python3.11-venv and gcc-9 in cpubuilder dockerfile.

### DIFF
--- a/dockerfiles/cpubuilder_ubuntu_jammy_ghr_x86_64.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy_ghr_x86_64.Dockerfile
@@ -4,17 +4,25 @@ FROM docker.io/myoung34/github-runner:ubuntu-jammy
 ######## Basic apt packages ########
 RUN apt update && \
     apt install -y \
-        wget python3.11-dev python3-pip git unzip curl gnupg2 lsb-release && \
-    update-alternatives --install /usr/local/bin/python python /usr/bin/python3.11 3 && \
-    update-alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.11 3 && \
+        wget git unzip curl gnupg2 lsb-release && \
     apt install -y \
         ccache clang-14 lld-14 libssl-dev ninja-build libxml2-dev llvm-dev pkg-config \
-        libcapstone-dev libtbb-dev libzstd-dev && \
-    apt clean && rm -rf /var/lib/apt/lists/*
+        libcapstone-dev libtbb-dev libzstd-dev
+# Python
+RUN apt install -y python3.11-dev python3.11-venv python3-pip && \
+    update-alternatives --install /usr/local/bin/python python /usr/bin/python3.11 3 && \
+    update-alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.11 3
+# Toolchains and build deps
+RUN apt install -y \
+        wget git unzip curl gnupg2 lsb-release \
+        ccache ninja-build clang-14 lld-14 gcc-9 g++-9 \
+        libssl-dev libxml2-dev libcapstone-dev libtbb-dev libzstd-dev \
+        llvm-dev pkg-config
+# Cleanup
+RUN apt clean && rm -rf /var/lib/apt/lists/*
 
 ######## CMake ########
 WORKDIR /install-cmake
-# Install our minimum supported CMake version.
 ENV CMAKE_VERSION="3.23.2"
 COPY build_tools/install_cmake.sh ./
 RUN ./install_cmake.sh "${CMAKE_VERSION}" && rm -rf /install-cmake

--- a/dockerfiles/cpubuilder_ubuntu_jammy_ghr_x86_64.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy_ghr_x86_64.Dockerfile
@@ -14,7 +14,6 @@ RUN apt install -y python3.11-dev python3.11-venv python3-pip && \
     update-alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.11 3
 # Toolchains and build deps
 RUN apt install -y \
-        wget git unzip curl gnupg2 lsb-release \
         ccache ninja-build clang-14 lld-14 gcc-9 g++-9 \
         libssl-dev libxml2-dev libcapstone-dev libtbb-dev libzstd-dev \
         llvm-dev pkg-config

--- a/dockerfiles/cpubuilder_ubuntu_jammy_x86_64.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy_x86_64.Dockerfile
@@ -4,17 +4,25 @@ FROM ubuntu:jammy
 ######## Basic apt packages ########
 RUN apt update && \
     apt install -y \
-        wget python3.11-dev python3-pip git unzip curl gnupg2 lsb-release && \
-    update-alternatives --install /usr/local/bin/python python /usr/bin/python3.11 3 && \
-    update-alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.11 3 && \
+        wget git unzip curl gnupg2 lsb-release && \
     apt install -y \
         ccache clang-14 lld-14 libssl-dev ninja-build libxml2-dev llvm-dev pkg-config \
-        libcapstone-dev libtbb-dev libzstd-dev && \
-    apt clean && rm -rf /var/lib/apt/lists/*
+        libcapstone-dev libtbb-dev libzstd-dev
+# Python
+RUN apt install -y python3.11-dev python3.11-venv python3-pip && \
+    update-alternatives --install /usr/local/bin/python python /usr/bin/python3.11 3 && \
+    update-alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.11 3
+# Toolchains and build deps
+RUN apt install -y \
+        wget git unzip curl gnupg2 lsb-release \
+        ccache ninja-build clang-14 lld-14 gcc-9 g++-9 \
+        libssl-dev libxml2-dev libcapstone-dev libtbb-dev libzstd-dev \
+        llvm-dev pkg-config
+# Cleanup
+RUN apt clean && rm -rf /var/lib/apt/lists/*
 
 ######## CMake ########
 WORKDIR /install-cmake
-# Install our minimum supported CMake version.
 ENV CMAKE_VERSION="3.23.2"
 COPY build_tools/install_cmake.sh ./
 RUN ./install_cmake.sh "${CMAKE_VERSION}" && rm -rf /install-cmake

--- a/dockerfiles/cpubuilder_ubuntu_jammy_x86_64.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy_x86_64.Dockerfile
@@ -14,7 +14,6 @@ RUN apt install -y python3.11-dev python3.11-venv python3-pip && \
     update-alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.11 3
 # Toolchains and build deps
 RUN apt install -y \
-        wget git unzip curl gnupg2 lsb-release \
         ccache ninja-build clang-14 lld-14 gcc-9 g++-9 \
         libssl-dev libxml2-dev libcapstone-dev libtbb-dev libzstd-dev \
         llvm-dev pkg-config


### PR DESCRIPTION
This should help get the byo_llvm and gcc builds working: https://github.com/iree-org/iree/pull/18356 .

Also grouped the installed packages a bit.

Tested with

```bash
# Host
sudo docker buildx build --file dockerfiles/cpubuilder_ubuntu_jammy_x86_64.dockerfile . --tag scotttodd/cpubuilder:latest
sudo docker run --rm --mount type=bind,source="/home/nod/dev/projects/iree",target=/iree -it --entrypoint bash scotttodd/cpubuilder:latest

# Docker
cd iree
./build_tools/cmake/build_and_test_byo_llvm.sh
```