### PR TITLE
Install clang-19 and clang-14 on cpubuilder, enabling ASan builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Image name | Description | Source Dockerfile
 ---------- | ----------- | -----------------
 `iree-org/amdgpu_ubuntu_jammy_x86_64` | Ubuntu with AMDGPU deps | [Source](./dockerfiles/amdgpu_ubuntu_jammy_x86_64.Dockerfile)
 `iree-org/amdgpu_ubuntu_jammy_ghr_x86_64` | Ubuntu with AMDGPU deps (GitHub runner) | [Source](./dockerfiles/amdgpu_ubuntu_jammy_ghr_x86_64.Dockerfile)
+`iree-org/cpubuilder_ubuntu_ghr_x86_64` | CPU builder with IREE build deps | [Source](./dockerfiles/cpubuilder_ubuntu_jammy_x86_64.Dockerfile)
 `iree-org/cpubuilder_ubuntu_jammy_ghr_x86_64` | CPU builder with IREE build deps (GitHub runner) | [Source](./dockerfiles/cpubuilder_ubuntu_jammy_ghr_x86_64.Dockerfile)
 `iree-org/manylinux_x86_64` | Portable Linux release builder for Python packaging | [Source](./dockerfiles/manylinux_x86_64.Dockerfile)
 `iree-org/manylinux_ghr_x86_64` | Portable Linux release builder for Python packaging (GitHub runner) | [Source](./dockerfiles/manylinux_ghr_x86_64.Dockerfile)
@@ -33,12 +34,21 @@ can be referenced using tags or hashes:
 
 To build locally, use a command like:
 
-```
+```bash
 sudo docker buildx build --file dockerfiles/some.Dockerfile .
 ```
 
 This will print a SHA image id, which you can run with:
 
-```
+```bash
 sudo docker run --rm -it --entrypoint /bin/bash <<IMAGE>>
+```
+
+You can also
+[tag an image](https://docs.docker.com/get-started/docker-concepts/building-images/build-tag-and-publish-an-image/)
+to avoid needing to copy the SHA each time:
+
+```bash
+sudo docker buildx build --file dockerfiles/cpubuilder_ubuntu_jammy_x86_64.Dockerfile . --tag cpubuilder:latest
+sudo docker run --rm --mount type=bind,source="realpath(~/iree)",target=/iree -it --entrypoint bash cpubuilder:latest
 ```

--- a/dockerfiles/cpubuilder_ubuntu_jammy_ghr_x86_64.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy_ghr_x86_64.Dockerfile
@@ -1,23 +1,27 @@
 # GitHub Actions Runner with IREE build deps.
 FROM docker.io/myoung34/github-runner:ubuntu-jammy
 
-######## Basic apt packages ########
+######## Apt packages ########
 RUN apt update && \
-    apt install -y \
-        wget git unzip curl gnupg2 lsb-release && \
-    apt install -y \
-        ccache clang-14 lld-14 libssl-dev ninja-build libxml2-dev llvm-dev pkg-config \
-        libcapstone-dev libtbb-dev libzstd-dev
-# Python
+    apt install -y wget git unzip curl gnupg2 lsb-release
+# Python 3.
 RUN apt install -y python3.11-dev python3.11-venv python3-pip && \
     update-alternatives --install /usr/local/bin/python python /usr/bin/python3.11 3 && \
     update-alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.11 3
-# Toolchains and build deps
+# Toolchains and build dependencies.
 RUN apt install -y \
-        ccache ninja-build clang-14 lld-14 gcc-9 g++-9 \
-        libssl-dev libxml2-dev libcapstone-dev libtbb-dev libzstd-dev \
-        llvm-dev pkg-config
-# Cleanup
+        clang-14 lld-14 \
+        gcc-9 g++-9 \
+        ccache ninja-build libssl-dev libxml2-dev libcapstone-dev libtbb-dev \
+        libzstd-dev llvm-dev pkg-config
+# Recent compiler tools for build configurations like ASan/TSan.
+#   * See https://apt.llvm.org/ for context on the apt commands.
+ARG LLVM_VERSION=19
+RUN echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_VERSION} main" >> /etc/apt/sources.list && \
+    curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/llvm-snapshot.gpg && \
+    apt update && \
+    apt install -y clang-${LLVM_VERSION} lld-${LLVM_VERSION}
+# Cleanup.
 RUN apt clean && rm -rf /var/lib/apt/lists/*
 
 ######## CMake ########
@@ -27,12 +31,12 @@ COPY build_tools/install_cmake.sh ./
 RUN ./install_cmake.sh "${CMAKE_VERSION}" && rm -rf /install-cmake
 
 ######## Build toolchain configuration ########
-# Setup symlinks and alternatives.
+# Setup symlinks and alternatives then default to using clang-14.
+# This can be overriden to gcc another clang version as needed.
 RUN ln -s /usr/bin/lld-14 /usr/bin/lld && \
     ln -s /usr/bin/ld.lld-14 /usr/bin/ld.lld && \
     ln -s /usr/bin/clang-14 /usr/bin/clang && \
     ln -s /usr/bin/clang++-14 /usr/bin/clang++
-# Default to using clang. This can be overriden to gcc as desired.
 ENV CC=clang
 ENV CXX=clang++
 

--- a/dockerfiles/cpubuilder_ubuntu_jammy_ghr_x86_64.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy_ghr_x86_64.Dockerfile
@@ -32,7 +32,7 @@ RUN ./install_cmake.sh "${CMAKE_VERSION}" && rm -rf /install-cmake
 
 ######## Build toolchain configuration ########
 # Setup symlinks and alternatives then default to using clang-14.
-# This can be overriden to gcc another clang version as needed.
+# This can be overriden to gcc or another clang version as needed.
 RUN ln -s /usr/bin/lld-14 /usr/bin/lld && \
     ln -s /usr/bin/ld.lld-14 /usr/bin/ld.lld && \
     ln -s /usr/bin/clang-14 /usr/bin/clang && \

--- a/dockerfiles/cpubuilder_ubuntu_jammy_x86_64.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy_x86_64.Dockerfile
@@ -1,23 +1,27 @@
-# Stock Ubuntu with IREE build deps.
+# Stock Ubuntu Jammy (22.04) with IREE build dependencies.
 FROM ubuntu:jammy
 
-######## Basic apt packages ########
+######## Apt packages ########
 RUN apt update && \
-    apt install -y \
-        wget git unzip curl gnupg2 lsb-release && \
-    apt install -y \
-        ccache clang-14 lld-14 libssl-dev ninja-build libxml2-dev llvm-dev pkg-config \
-        libcapstone-dev libtbb-dev libzstd-dev
-# Python
+    apt install -y wget git unzip curl gnupg2 lsb-release
+# Python 3.
 RUN apt install -y python3.11-dev python3.11-venv python3-pip && \
     update-alternatives --install /usr/local/bin/python python /usr/bin/python3.11 3 && \
     update-alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.11 3
-# Toolchains and build deps
+# Toolchains and build dependencies.
 RUN apt install -y \
-        ccache ninja-build clang-14 lld-14 gcc-9 g++-9 \
-        libssl-dev libxml2-dev libcapstone-dev libtbb-dev libzstd-dev \
-        llvm-dev pkg-config
-# Cleanup
+        clang-14 lld-14 \
+        gcc-9 g++-9 \
+        ccache ninja-build libssl-dev libxml2-dev libcapstone-dev libtbb-dev \
+        libzstd-dev llvm-dev pkg-config
+# Recent compiler tools for build configurations like ASan/TSan.
+#   * See https://apt.llvm.org/ for context on the apt commands.
+ARG LLVM_VERSION=19
+RUN echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_VERSION} main" >> /etc/apt/sources.list && \
+    curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/llvm-snapshot.gpg && \
+    apt update && \
+    apt install -y clang-${LLVM_VERSION} lld-${LLVM_VERSION}
+# Cleanup.
 RUN apt clean && rm -rf /var/lib/apt/lists/*
 
 ######## CMake ########
@@ -27,12 +31,12 @@ COPY build_tools/install_cmake.sh ./
 RUN ./install_cmake.sh "${CMAKE_VERSION}" && rm -rf /install-cmake
 
 ######## Build toolchain configuration ########
-# Setup symlinks and alternatives.
+# Setup symlinks and alternatives then default to using clang-14.
+# This can be overriden to gcc another clang version as needed.
 RUN ln -s /usr/bin/lld-14 /usr/bin/lld && \
     ln -s /usr/bin/ld.lld-14 /usr/bin/ld.lld && \
     ln -s /usr/bin/clang-14 /usr/bin/clang && \
     ln -s /usr/bin/clang++-14 /usr/bin/clang++
-# Default to using clang. This can be overriden to gcc as desired.
 ENV CC=clang
 ENV CXX=clang++
 

--- a/dockerfiles/cpubuilder_ubuntu_jammy_x86_64.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy_x86_64.Dockerfile
@@ -32,7 +32,7 @@ RUN ./install_cmake.sh "${CMAKE_VERSION}" && rm -rf /install-cmake
 
 ######## Build toolchain configuration ########
 # Setup symlinks and alternatives then default to using clang-14.
-# This can be overriden to gcc another clang version as needed.
+# This can be overriden to gcc or another clang version as needed.
 RUN ln -s /usr/bin/lld-14 /usr/bin/lld && \
     ln -s /usr/bin/ld.lld-14 /usr/bin/ld.lld && \
     ln -s /usr/bin/clang-14 /usr/bin/clang && \


### PR DESCRIPTION
Tested with the [`build_tools/cmake/build_and_test_asan.sh`](https://github.com/iree-org/iree/blob/main/build_tools/cmake/build_and_test_asan.sh) script from IREE. When I tried to build with ASan on clang-14, I got segfaults in llvm-tblgen and other tools. Not sure if that could be made to work, but rolling forward to a newer compiler seems fine for a sanitizer build.

In the IREE repo, we had a split between `base` and `base-bleeding-edge` dockerfiles. Here, I'm just installing multiple compilers and letting the job choose between them (as on GitHub-managed runners). The binary size increase is fairly minor in the grand scheme of things.

The diff to use this from IREE will look like this, at least for ASan (still working on TSan):
```diff
~/dev/projects/iree (users/scotttodd/ci_linux_x64_clang)$ git diff
diff --git a/.github/workflows/ci_linux_x64_clang_asan.yml b/.github/workflows/ci_linux_x64_clang_asan.yml
index d3d291af98..9274e84d67 100644
--- a/.github/workflows/ci_linux_x64_clang_asan.yml
+++ b/.github/workflows/ci_linux_x64_clang_asan.yml
@@ -34,21 +34,21 @@ jobs:
       - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
+    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:latest
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@v4.1.7
         with:
           submodules: true
-      - name: "Building and testing with ASan"
+      - name: Install Python requirements
+        run: python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+      # TODO(#18238): add local or remote ccache
+      - name: Build and test with ASan
         env:
-          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
-        run: |
-          # Note that this uses the latest version of the clang compiler, etc.
-          # This gives us access to the latest features and validates that IREE
-          # builds using the latest versions.
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
-            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
-            --env "CCACHE_NAMESPACE=base-bleeding-edge@sha256:14200dacca3a0f3a66f8aa87c6f64729b83a2eeb403b689c24204074ad157418" \
-            gcr.io/iree-oss/base-bleeding-edge@sha256:cf2e78194e64fd0166f4141317366261d7a62432b72e9a324cb8c2ff4e1a515a \
-            ./build_tools/cmake/build_and_test_asan.sh
+          # The default compiler in this container (clang-14) is too old for ASan.
+          CC: clang-19
+          CXX: clang++-19
+        run: ./build_tools/cmake/build_and_test_asan.sh
```