### PR TITLE
Install sccache in cpubuilder dockerfiles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ to avoid needing to copy the SHA each time:
 
 ```bash
 sudo docker buildx build --file dockerfiles/cpubuilder_ubuntu_jammy_x86_64.Dockerfile . --tag cpubuilder:latest
-sudo docker run --rm --mount type=bind,source="realpath(~/iree)",target=/iree -it --entrypoint bash cpubuilder:latest
+sudo docker run --rm --mount type=bind,source="$(realpath ~/iree)",target=/iree -it --entrypoint bash cpubuilder:latest
 ```

--- a/build_tools/install_sccache.sh
+++ b/build_tools/install_sccache.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set -xeuo pipefail
+
+SCCACHE_VERSION="$1"
+
+ARCH="$(uname -m)"
+
+curl --silent --fail --show-error --location \
+    "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-${ARCH}-unknown-linux-musl.tar.gz" \
+    --output sccache.tar.gz
+
+tar xf sccache.tar.gz
+cp sccache-v${SCCACHE_VERSION}-${ARCH}-unknown-linux-musl/sccache /usr/local/bin

--- a/dockerfiles/cpubuilder_ubuntu_jammy_ghr_x86_64.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy_ghr_x86_64.Dockerfile
@@ -9,7 +9,8 @@ RUN apt install -y python3.11-dev python3.11-venv python3-pip && \
     update-alternatives --install /usr/local/bin/python python /usr/bin/python3.11 3 && \
     update-alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.11 3
 # Toolchains and build dependencies.
-RUN apt install -y \
+RUN apt update && \
+    apt install -y \
         clang-14 lld-14 \
         gcc-9 g++-9 \
         ninja-build libssl-dev libxml2-dev libcapstone-dev libtbb-dev \
@@ -34,6 +35,11 @@ RUN apt clean && rm -rf /var/lib/apt/lists/*
 WORKDIR /install-ccache
 COPY build_tools/install_ccache.sh ./
 RUN ./install_ccache.sh "4.10.2" && rm -rf /install-ccache
+
+######## sccache ########
+WORKDIR /install-sccache
+COPY build_tools/install_sccache.sh ./
+RUN ./install_sccache.sh "0.8.1" && rm -rf /install-sccache
 
 ######## CMake ########
 WORKDIR /install-cmake

--- a/dockerfiles/cpubuilder_ubuntu_jammy_x86_64.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy_x86_64.Dockerfile
@@ -9,7 +9,8 @@ RUN apt install -y python3.11-dev python3.11-venv python3-pip && \
     update-alternatives --install /usr/local/bin/python python /usr/bin/python3.11 3 && \
     update-alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.11 3
 # Toolchains and build dependencies.
-RUN apt install -y \
+RUN apt update && \
+    apt install -y \
         clang-14 lld-14 \
         gcc-9 g++-9 \
         ninja-build libssl-dev libxml2-dev libcapstone-dev libtbb-dev \
@@ -34,6 +35,11 @@ RUN apt clean && rm -rf /var/lib/apt/lists/*
 WORKDIR /install-ccache
 COPY build_tools/install_ccache.sh ./
 RUN ./install_ccache.sh "4.10.2" && rm -rf /install-ccache
+
+######## sccache ########
+WORKDIR /install-sccache
+COPY build_tools/install_sccache.sh ./
+RUN ./install_sccache.sh "0.8.1" && rm -rf /install-sccache
 
 ######## CMake ########
 WORKDIR /install-cmake


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/18238

https://github.com/mozilla/sccache

We may use this instead of ccache for our shared remote cache usage, consider sccache has first class Azure Blob Storage support: https://github.com/mozilla/sccache/blob/main/docs/Azure.md.