### PR TITLE
Install Bazel in cpubuilder dockerfiles.

### DIFF
--- a/dockerfiles/cpubuilder_ubuntu_jammy_ghr_x86_64.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy_ghr_x86_64.Dockerfile
@@ -47,6 +47,12 @@ ENV CMAKE_VERSION="3.23.2"
 COPY build_tools/install_cmake.sh ./
 RUN ./install_cmake.sh "${CMAKE_VERSION}" && rm -rf /install-cmake
 
+######## Bazel ########
+ARG BAZEL_VERSION=6.5.0
+WORKDIR /install-bazel
+COPY build_tools/install_bazel.sh ./
+RUN ./install_bazel.sh && rm -rf /install-bazel
+
 ######## Build toolchain configuration ########
 # Setup symlinks and alternatives then default to using clang-14.
 # This can be overriden to gcc or another clang version as needed.

--- a/dockerfiles/cpubuilder_ubuntu_jammy_x86_64.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy_x86_64.Dockerfile
@@ -47,6 +47,12 @@ ENV CMAKE_VERSION="3.23.2"
 COPY build_tools/install_cmake.sh ./
 RUN ./install_cmake.sh "${CMAKE_VERSION}" && rm -rf /install-cmake
 
+######## Bazel ########
+ARG BAZEL_VERSION=6.5.0
+WORKDIR /install-bazel
+COPY build_tools/install_bazel.sh ./
+RUN ./install_bazel.sh && rm -rf /install-bazel
+
 ######## Build toolchain configuration ########
 # Setup symlinks and alternatives then default to using clang-14.
 # This can be overriden to gcc or another clang version as needed.


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/15332. With this we should be able to switch `build_test_all_bazel` from `gcr.io/iree-oss/base-bleeding-edge` to this cpubuilder dockerfile.

This installs the version listed at https://github.com/iree-org/iree/blob/main/.bazelversion. We could also use https://github.com/bazelbuild/bazelisk to install whatever version is needed on demand, but this is updated infrequently enough that explicitly installing a version may be fine for a while.

Tested a bit locally with https://github.com/iree-org/iree/blob/main/build_tools/bazel/build_test_all.sh . Some other changes are needed to migrate off of GCP:

* Install numpy (https://iree.dev/developers/building/bazel/#prerequisites)
* Drop `--config=rs` (skipping the remote cache setup from https://github.com/iree-org/iree/blob/main/build_tools/bazel/iree.bazelrc)
* Seeing errors I don't understand yet from spirv-tools... which we shouldn't be using here?
    
    > ERROR: /iree/build/_deps/spirv-tools-src/BUILD.bazel:91:8: no such package '@spirv_headers//': The repository '@spirv_headers' could not be resolved: Repository '@spirv_headers' is not defined and referenced by '//build/_deps/spirv-tools-src:generators_inc'
    > ...
    > ERROR: /iree/build/_deps/spirv-tools-src/BUILD.bazel:557:9: no such package '@com_google_effcee//': The repository '@com_google_effcee' could not be resolved: Repository '@com_google_effcee' is not defined and referenced by '//build/_deps/spirv-tools-src:opt_analyze_live_input_test'

    https://github.com/KhronosGroup/SPIRV-Tools/ has info on what is expected... if we were actually using it

I did not measure the binary size increase from this change. I'm not too concerned, but this could be getting into slippery slope / death-by-a-thousand-papercuts territory.