### PR TITLE
Disable LLVM version 19 install while apt.llvm.org is broken.

### DIFF
--- a/dockerfiles/cpubuilder_ubuntu_jammy_ghr_x86_64.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy_ghr_x86_64.Dockerfile
@@ -15,13 +15,14 @@ RUN apt update && \
         gcc-9 g++-9 \
         ninja-build libssl-dev libxml2-dev libcapstone-dev libtbb-dev \
         libzstd-dev llvm-dev pkg-config
+# TODO: re-enable this when LLVM apt packages are working again
 # Recent compiler tools for build configurations like ASan/TSan.
 #   * See https://apt.llvm.org/ for context on the apt commands.
-ARG LLVM_VERSION=19
-RUN echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_VERSION} main" >> /etc/apt/sources.list && \
-    curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/llvm-snapshot.gpg && \
-    apt update && \
-    apt install -y clang-${LLVM_VERSION} lld-${LLVM_VERSION}
+# ARG LLVM_VERSION=19
+# RUN echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_VERSION} main" >> /etc/apt/sources.list && \
+#     curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/llvm-snapshot.gpg && \
+#     apt update && \
+#     apt install -y clang-${LLVM_VERSION} lld-${LLVM_VERSION}
 # Cleanup.
 RUN apt clean && rm -rf /var/lib/apt/lists/*
 

--- a/dockerfiles/cpubuilder_ubuntu_jammy_x86_64.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy_x86_64.Dockerfile
@@ -15,13 +15,14 @@ RUN apt update && \
         gcc-9 g++-9 \
         ninja-build libssl-dev libxml2-dev libcapstone-dev libtbb-dev \
         libzstd-dev llvm-dev pkg-config
+# TODO: re-enable this when LLVM apt packages are working again
 # Recent compiler tools for build configurations like ASan/TSan.
 #   * See https://apt.llvm.org/ for context on the apt commands.
-ARG LLVM_VERSION=19
-RUN echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_VERSION} main" >> /etc/apt/sources.list && \
-    curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/llvm-snapshot.gpg && \
-    apt update && \
-    apt install -y clang-${LLVM_VERSION} lld-${LLVM_VERSION}
+# ARG LLVM_VERSION=19
+# RUN echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_VERSION} main" >> /etc/apt/sources.list && \
+#     curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/llvm-snapshot.gpg && \
+#     apt update && \
+#     apt install -y clang-${LLVM_VERSION} lld-${LLVM_VERSION}
 # Cleanup.
 RUN apt clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
See logs here: https://github.com/iree-org/base-docker-images/actions/runs/10948538407/job/30399779213

Upstream tracking issue: https://github.com/llvm/llvm-project/issues/109276

We need a recent LLVM compiler in our ASan/TSan workflows, so those should stay pinned to older images until we can re-enable this install.