### PR TITLE
Install QEMU emulator in arm64 variant of cpubuilder image.

### DIFF
--- a/build_tools/install_arch_extras_amd64.sh
+++ b/build_tools/install_arch_extras_amd64.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set -euo pipefail
+
+# No extras :D

--- a/build_tools/install_arch_extras_arm64.sh
+++ b/build_tools/install_arch_extras_arm64.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set -euo pipefail
+
+# QEMU for aarch64
+wget --no-verbose "https://sharkpublic.blob.core.windows.net/sharkpublic/GCP-Migration-Files/qemu-aarch64"
+chmod +x ./qemu-aarch64
+mv ./qemu-aarch64 /usr/bin/qemu-aarch64

--- a/dockerfiles/cpubuilder_ubuntu_jammy.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy.Dockerfile
@@ -55,4 +55,9 @@ WORKDIR /install-sccache
 COPY build_tools/install_sccache.sh ./
 RUN ./install_sccache.sh "0.8.1" && rm -rf /install-sccache
 
+######## target-architecture-specific installs ########
+WORKDIR /install-target-arch
+COPY build_tools/install_arch_extras_${TARGETARCH}.sh ./
+RUN ./install_arch_extras_${TARGETARCH}.sh && rm -rf /install-target-arch
+
 WORKDIR /

--- a/dockerfiles/cpubuilder_ubuntu_jammy_ghr.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy_ghr.Dockerfile
@@ -55,5 +55,10 @@ WORKDIR /install-sccache
 COPY build_tools/install_sccache.sh ./
 RUN ./install_sccache.sh "0.8.1" && rm -rf /install-sccache
 
+######## target-architecture-specific installs ########
+WORKDIR /install-target-arch
+COPY build_tools/install_arch_extras_${TARGETARCH}.sh ./
+RUN ./install_arch_extras_${TARGETARCH}.sh && rm -rf /install-target-arch
+
 # Switch back to the working directory upstream expects.
 WORKDIR /actions-runner


### PR DESCRIPTION
Follow-up to https://github.com/iree-org/base-docker-images/pull/11.

This emulator was originally installed in https://github.com/iree-org/iree/pull/16331. We've been carrying it around since then.

I'm not thrilled with the file sitting in a cloud storage bucket (GCS or Azure). The file is 5MB so maybe we could check it in here via git LFS? Or we could build it from source via our automation.