### PR TITLE
Re-enable llvm 19 in cpubuilder dockerfile.

### DIFF
--- a/dockerfiles/cpubuilder_ubuntu_jammy.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy.Dockerfile
@@ -18,14 +18,13 @@ RUN apt update && \
         gcc-9 g++-9 \
         ninja-build libssl-dev libxml2-dev libcapstone-dev libtbb-dev \
         libzstd-dev llvm-dev pkg-config
-# TODO: re-enable this when LLVM apt packages are working again
 # Recent compiler tools for build configurations like ASan/TSan.
 #   * See https://apt.llvm.org/ for context on the apt commands.
-# ARG LLVM_VERSION=19
-# RUN echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_VERSION} main" >> /etc/apt/sources.list && \
-#     curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/llvm-snapshot.gpg && \
-#     apt update && \
-#     apt install -y clang-${LLVM_VERSION} lld-${LLVM_VERSION}
+ARG LLVM_VERSION=19
+RUN echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_VERSION} main" >> /etc/apt/sources.list && \
+    curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/llvm-snapshot.gpg && \
+    apt update && \
+    apt install -y clang-${LLVM_VERSION} lld-${LLVM_VERSION}
 # Cleanup.
 RUN apt clean && rm -rf /var/lib/apt/lists/*
 

--- a/dockerfiles/cpubuilder_ubuntu_jammy_ghr.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_jammy_ghr.Dockerfile
@@ -18,14 +18,13 @@ RUN apt update && \
         gcc-9 g++-9 \
         ninja-build libssl-dev libxml2-dev libcapstone-dev libtbb-dev \
         libzstd-dev llvm-dev pkg-config
-# TODO: re-enable this when LLVM apt packages are working again
 # Recent compiler tools for build configurations like ASan/TSan.
 #   * See https://apt.llvm.org/ for context on the apt commands.
-# ARG LLVM_VERSION=19
-# RUN echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_VERSION} main" >> /etc/apt/sources.list && \
-#     curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/llvm-snapshot.gpg && \
-#     apt update && \
-#     apt install -y clang-${LLVM_VERSION} lld-${LLVM_VERSION}
+ARG LLVM_VERSION=19
+RUN echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_VERSION} main" >> /etc/apt/sources.list && \
+    curl https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/llvm-snapshot.gpg && \
+    apt update && \
+    apt install -y clang-${LLVM_VERSION} lld-${LLVM_VERSION}
 # Cleanup.
 RUN apt clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Manual revert of https://github.com/iree-org/base-docker-images/pull/12.

apt.llvm.org should be working again now.

Untested. If the build fails after push we can just revert.