### PR TITLE
Update manylinux dockerfile: add Python 3.13, drop ROCm and Bazel.

### DIFF
--- a/dockerfiles/manylinux_x86_64.Dockerfile
+++ b/dockerfiles/manylinux_x86_64.Dockerfile
@@ -1,7 +1,8 @@
 # We build our portable linux releases on the manylinux (RHEL-based)
 # images, with custom additional packages installed. We switch to
 # new upstream versions as needed.
-FROM quay.io/pypa/manylinux_2_28_x86_64@sha256:9042a22d33af2223ff7a3599f236aff1e4ffd07e1ed1ac93a58877638317515f
+# See https://github.com/pypa/manylinux and https://quay.io/organization/pypa.
+FROM quay.io/pypa/manylinux_2_28_x86_64@sha256:cea0ade79068b36deae7eb7a04b4192e5ba2761d045ba5a92ba36eb5ce5f88b6
 
 RUN yum install -y epel-release && \
     yum install -y ccache clang lld && \

--- a/dockerfiles/manylinux_x86_64.Dockerfile
+++ b/dockerfiles/manylinux_x86_64.Dockerfile
@@ -7,26 +7,8 @@ FROM quay.io/pypa/manylinux_2_28_x86_64@sha256:cea0ade79068b36deae7eb7a04b4192e5
 RUN yum install -y epel-release && \
     yum install -y ccache clang lld && \
     yum install -y capstone-devel tbb-devel libzstd-devel && \
-    yum install -y java-11-openjdk-devel && \
     yum clean all && \
     rm -rf /var/cache/yum
-
-######## AMD ROCM #######
-ARG ROCM_VERSION=5.2.1
-ARG AMDGPU_VERSION=22.20.1
-ARG RHEL_VERSION=8.6
-
-# Install the ROCm rpms
-RUN  echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/yum/${ROCM_VERSION}/main\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/rocm.repo \
-  && echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/${AMDGPU_VERSION}/rhel/${RHEL_VERSION}/main/x86_64\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/amdgpu.repo \
-  && yum install -y rocm-dev \
-  && yum clean all
-
-######## Bazel ########
-ARG BAZEL_VERSION=5.1.0
-WORKDIR /install-bazel
-COPY build_tools/install_bazel.sh ./
-RUN ./install_bazel.sh && rm -rf /install-bazel
 
 ######## GIT CONFIGURATION ########
 # Git started enforcing strict user checking, which thwarts version


### PR DESCRIPTION
This will help us publish Python 3.13 and 3.13t wheels: https://github.com/iree-org/iree/issues/18652.

Tested 3.13 locally with:
```bash
cd base-docker-images
sudo docker buildx build --file dockerfiles/manylinux_x86_64.Dockerfile . --tag manylinux:latest

cd iree
manylinux_docker_image=manylinux:latest override_python_versions=cp313-cp313 packages="iree-runtime iree-compiler" sudo -E ./build_tools/python_deploy/build_linux_packages.sh
```

The ROCm and Bazel deps appeared to be unused in this dockerfile, so I pruned them. We also aren't using the "ghr" flavored version of this dockerfile (https://github.com/iree-org/base-docker-images/blob/main/dockerfiles/manylinux_ghr_x86_64.Dockerfile), which has diverged quite substantially, so I did not update that file.