### PR TITLE
Add a pkgci_mi300 docker file to avoid installing dependencies every run

### DIFF
--- a/.github/workflows/publish_pkgci_mi300.yml
+++ b/.github/workflows/publish_pkgci_mi300.yml
@@ -1,0 +1,44 @@
+name: Publish manylinux_x86_64 image
+on:
+  workflow_dispatch:
+  push:
+    branches: ['main']
+    paths:
+    - dockerfiles/pkgci_mi300.Dockerfile
+    - .github/workflows/publish_pkgci_mi300.yml
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: iree-org/pkgci_mi300
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Log in to the Container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
+        with:
+          context: .
+          file: dockerfiles/pkgci_mi300.Dockerfile.Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/dockerfiles/pkgci_amd_mi300.Dockerfile
+++ b/dockerfiles/pkgci_amd_mi300.Dockerfile
@@ -1,0 +1,17 @@
+# fetching ubuntu/dists/jammy in every workflow fails around 20%
+# pre-installed the dependencies
+FROM rocm/dev-ubuntu-22.04:6.3
+
+RUN apt-get -y update && \
+    apt-get install -y cmake ninja-build clang lld git
+
+######## GIT CONFIGURATION ########
+# Git started enforcing strict user checking, which thwarts version
+# configuration scripts in a docker image where the tree was checked
+# out by the host and mapped in. Disable the check.
+# See: https://github.com/iree-org/iree/issues/12046
+# We use the wildcard option to disable the checks. This was added
+# in git 2.35.3
+RUN git config --global --add safe.directory '*'
+
+WORKDIR /


### PR DESCRIPTION
The pkgci_mi300 workflow currently pulls rcom base image and install dependencies, however, it is failing 20% due to ubuntu jammy inaccessible. This PR creates a new Dockerfile to have all the dependencies pre-installed.