### PR TITLE
Pin workflows to ubuntu-24.04 instead of ubuntu-latest.

### DIFF
--- a/.github/workflows/publish_amdgpu_x86_64.yml
+++ b/.github/workflows/publish_amdgpu_x86_64.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-amdgpu-ubuntu-jammy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: iree-org/amdgpu_ubuntu_jammy_x86_64
@@ -43,7 +43,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   build-amdgpu-ubuntu-jammy-ghr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: iree-org/amdgpu_ubuntu_jammy_ghr_x86_64

--- a/.github/workflows/publish_cpubuilder.yml
+++ b/.github/workflows/publish_cpubuilder.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-cpubuilder-ubuntu-jammy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: iree-org/cpubuilder_ubuntu_jammy
@@ -46,7 +46,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   build-cpubuilder-ubuntu-jammy-ghr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: iree-org/cpubuilder_ubuntu_jammy_ghr

--- a/.github/workflows/publish_manylinux_ghr_x86_64.yml
+++ b/.github/workflows/publish_manylinux_ghr_x86_64.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read

--- a/.github/workflows/publish_manylinux_x86_64.yml
+++ b/.github/workflows/publish_manylinux_x86_64.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read


### PR DESCRIPTION
Pinned dependencies are recommended here: https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies