### PR TITLE
Add ghascale cpubuilder and amdgpu docker images.

### DIFF
--- a/.github/workflows/publish_amdgpu_ubuntu_ghascale.yml
+++ b/.github/workflows/publish_amdgpu_ubuntu_ghascale.yml
@@ -1,0 +1,19 @@
+name: Publish amdgpu ghascale images
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches: ['main']
+    paths:
+    - dockerfiles/amdgpu_ubuntu_ghascale.Dockerfile
+    - .github/workflows/publish_amdgpu_ubuntu_ghascale.yml
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-amdgpu-ubuntu-ghascale:
+    uses: ./.github/workflows/publish_dockerfile.yml
+    with:
+        DOCKERFILE_NAME: amdgpu_ubuntu_ghascale

--- a/.github/workflows/publish_amdgpu_ubuntu_ghascale.yml
+++ b/.github/workflows/publish_amdgpu_ubuntu_ghascale.yml
@@ -1,7 +1,8 @@
 name: Publish amdgpu ghascale images
 on:
-  pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '30 5 * * *'
   push:
     branches: ['main']
     paths:

--- a/.github/workflows/publish_cpubuilder.yml
+++ b/.github/workflows/publish_cpubuilder.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ['main']
     paths:
-    - dockerfiles/cpubuilder*.Dockerfile
+    - dockerfiles/cpubuilder_ubuntu_jammy*.Dockerfile
     - .github/workflows/publish_cpubuilder.yml
 
 permissions:

--- a/.github/workflows/publish_cpubuilder_ubuntu_ghascale.yml
+++ b/.github/workflows/publish_cpubuilder_ubuntu_ghascale.yml
@@ -1,7 +1,8 @@
 name: Publish ghascale cpubuilder images
 on:
-  pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '30 5 * * *'
   push:
     branches: ['main']
     paths:

--- a/.github/workflows/publish_cpubuilder_ubuntu_ghascale.yml
+++ b/.github/workflows/publish_cpubuilder_ubuntu_ghascale.yml
@@ -1,0 +1,19 @@
+name: Publish ghascale cpubuilder images
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches: ['main']
+    paths:
+    - dockerfiles/cpubuilder_ubuntu_ghascale.Dockerfile
+    - .github/workflows/publish_cpubuilder_ubuntu_ghascale.yml
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-cpubuilder-ubuntu-ghascale:
+    uses: ./.github/workflows/publish_dockerfile.yml
+    with:
+        DOCKERFILE_NAME: cpubuilder_ubuntu_ghascale

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ These images build and publish automatically using GitHub Actions.
 Image name | Description | Source Dockerfile
 ---------- | ----------- | -----------------
 `iree-org/amdgpu_ubuntu_jammy_x86_64` | Ubuntu with AMDGPU deps | [Source](./dockerfiles/amdgpu_ubuntu_jammy_x86_64.Dockerfile)
+`iree-org/amdgpu_ubuntu_ghascale` | Ubuntu with AMDGPU deps (GitHub Runner Scale Set) | [Source](./dockerfiles/amdgpu_ubuntu_ghascale.Dockerfile)
 `iree-org/amdgpu_ubuntu_jammy_ghr_x86_64` | Ubuntu with AMDGPU deps (GitHub runner) | [Source](./dockerfiles/amdgpu_ubuntu_jammy_ghr_x86_64.Dockerfile)
 `iree-org/cpubuilder_ubuntu_jammy` | CPU builder with IREE build deps | [Source](./dockerfiles/cpubuilder_ubuntu_jammy.Dockerfile)
+`iree-org/cpubuilder_ubuntu_ghascale` | CPU builder with IREE build deps (GitHub Runner Scale Set) | [Source](./dockerfiles/cpubuilder_ubuntu_ghascale.Dockerfile)
 `iree-org/cpubuilder_ubuntu_jammy_ghr` | CPU builder with IREE build deps (GitHub runner) | [Source](./dockerfiles/cpubuilder_ubuntu_jammy_ghr.Dockerfile)
 `iree-org/manylinux_x86_64` | Portable Linux release builder for Python packaging | [Source](./dockerfiles/manylinux_x86_64.Dockerfile)
 `iree-org/manylinux_ghr_x86_64` | Portable Linux release builder for Python packaging (GitHub runner) | [Source](./dockerfiles/manylinux_ghr_x86_64.Dockerfile)

--- a/dockerfiles/amdgpu_ubuntu_ghascale.Dockerfile
+++ b/dockerfiles/amdgpu_ubuntu_ghascale.Dockerfile
@@ -1,0 +1,35 @@
+FROM ghcr.io/actions/actions-runner:latest
+
+RUN sudo apt-get update -y \
+    && sudo apt-get install -y software-properties-common \
+    && sudo add-apt-repository -y ppa:git-core/ppa \
+    && sudo apt-get update -y \
+    && sudo apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    git \
+    jq \
+    sudo \
+    unzip \
+    zip \
+    cmake \
+    ninja-build \
+    clang \
+    lld \
+    wget \
+    psmisc \
+    python3.10-venv \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && \
+    sudo apt-get install git-lfs
+
+RUN sudo groupadd -g 109 render
+
+RUN sudo apt update -y \
+    && sudo apt install python3-setuptools python3-wheel libpython3.10 \
+    && sudo usermod -a -G render,video runner \
+    && wget https://repo.radeon.com/amdgpu-install/6.4/ubuntu/jammy/amdgpu-install_6.4.60400-1_all.deb \
+    && sudo apt install -y ./amdgpu-install_6.4.60400-1_all.deb \
+    && sudo apt update -y \
+    && sudo apt install -y rocm-dev

--- a/dockerfiles/amdgpu_ubuntu_ghascale.Dockerfile
+++ b/dockerfiles/amdgpu_ubuntu_ghascale.Dockerfile
@@ -1,5 +1,6 @@
 FROM ghcr.io/actions/actions-runner:latest
 
+# base dependencies
 RUN sudo apt-get update -y \
     && sudo apt-get install -y software-properties-common \
     && sudo add-apt-repository -y ppa:git-core/ppa \
@@ -18,16 +19,20 @@ RUN sudo apt-get update -y \
     lld \
     wget \
     psmisc \
-    python3.10-venv \
+    python3-setuptools \
+    python3-wheel \
+    libpython3.10 \
+    python3.10-venv
     && sudo rm -rf /var/lib/apt/lists/*
 
+# git lfs install
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && \
     sudo apt-get install git-lfs
 
 RUN sudo groupadd -g 109 render
 
+# ROCm install
 RUN sudo apt update -y \
-    && sudo apt install python3-setuptools python3-wheel libpython3.10 \
     && sudo usermod -a -G render,video runner \
     && wget https://repo.radeon.com/amdgpu-install/6.4/ubuntu/jammy/amdgpu-install_6.4.60400-1_all.deb \
     && sudo apt install -y ./amdgpu-install_6.4.60400-1_all.deb \

--- a/dockerfiles/cpubuilder_ubuntu_ghascale.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_ghascale.Dockerfile
@@ -1,5 +1,6 @@
 FROM ghcr.io/actions/actions-runner:latest
 
+# base dependencies
 RUN sudo apt-get update -y \
     && sudo apt-get install -y software-properties-common \
     && sudo add-apt-repository -y ppa:git-core/ppa \
@@ -18,5 +19,6 @@ RUN sudo apt-get update -y \
     lld \
     && sudo rm -rf /var/lib/apt/lists/*
 
+# git lfs install
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && \
     sudo apt-get install git-lfs

--- a/dockerfiles/cpubuilder_ubuntu_ghascale.Dockerfile
+++ b/dockerfiles/cpubuilder_ubuntu_ghascale.Dockerfile
@@ -1,0 +1,22 @@
+FROM ghcr.io/actions/actions-runner:latest
+
+RUN sudo apt-get update -y \
+    && sudo apt-get install -y software-properties-common \
+    && sudo add-apt-repository -y ppa:git-core/ppa \
+    && sudo apt-get update -y \
+    && sudo apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    git \
+    jq \
+    sudo \
+    unzip \
+    zip \
+    cmake \
+    ninja-build \
+    clang \
+    lld \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && \
+    sudo apt-get install git-lfs


### PR DESCRIPTION
This PR adds the cpubuilder and amdgpu ghascale images that we have been using in `iree-org`.

Previously hosted here:
https://github.com/saienduri/docker-images/blob/main/ghascale.Dockerfile
https://github.com/saienduri/docker-images/blob/main/ghascale-rocm.Dockerfile (upgraded this to rocm 6.4 in the image added to this repo)

Tested builds here:
https://github.com/iree-org/base-docker-images/actions/runs/14767541047
https://github.com/iree-org/base-docker-images/actions/runs/14767541040