### PR TITLE
Small fix to amdgpu ghascale docker.

### DIFF
--- a/dockerfiles/amdgpu_ubuntu_ghascale.Dockerfile
+++ b/dockerfiles/amdgpu_ubuntu_ghascale.Dockerfile
@@ -22,7 +22,7 @@ RUN sudo apt-get update -y \
     python3-setuptools \
     python3-wheel \
     libpython3.10 \
-    python3.10-venv
+    python3.10-venv \
     && sudo rm -rf /var/lib/apt/lists/*
 
 # git lfs install


### PR DESCRIPTION
Oops, I should have checked with a build when committing the reformatting commit: https://github.com/iree-org/base-docker-images/pull/31/commits/ab230419f7bd01431dcd49e671b0bf4ba10a91cd 

But, this is a quick fix so the build works. Maybe we should trigger a build requirement for CI also? It wouldn't publish to `main` which we can use for the actual runners.
 